### PR TITLE
Add EGTCHT_Combo widget

### DIFF
--- a/src/pyefis/config/includes/bars/vertical/EGTCHT_Combo.yaml
+++ b/src/pyefis/config/includes/bars/vertical/EGTCHT_Combo.yaml
@@ -1,0 +1,18 @@
+instruments:
+  - type: EGTCHT_Combo
+    rows: 4
+    cols: 2
+    gappct: 0.05
+    headpct: 0.1
+    EGT:
+      minlimit: 1000
+      warnlimit: 1300
+      maxlimit: 1600
+      maxextendpct: 0.1
+      dbkeys: [EGT1, EGT2, EGT3, EGT4]
+    CHT:
+      minlimit: 300
+      warnlimit: 400
+      maxlimit: 500
+      maxextendpct: 0.1
+      dbkeys: [CHT1, CHT2, CHT3, CHT4]

--- a/src/pyefis/instruments/gauges/EGTCHT_Combo.py
+++ b/src/pyefis/instruments/gauges/EGTCHT_Combo.py
@@ -1,0 +1,105 @@
+from PyQt6.QtWidgets import QWidget
+from PyQt6.QtGui import QColor, QFont, QPainter, QPen
+from PyQt6.QtCore import Qt, QTimer, QRectF, pyqtSignal
+import pyavtools.fix as fix
+
+class EGTCHT_Combo(QWidget):
+    def __init__(self, parent=None, config=None):
+        super(EGTCHT_Combo, self).__init__(parent)
+        self.config = config
+        self.rows = config.get("rows", 1)
+        self.cols = config.get("cols", 1)
+        self.gappct = config.get("gappct", 0.05)
+        self.headpct = config.get("headpct", 0.1)
+        self.EGT = config.get("EGT", {})
+        self.CHT = config.get("CHT", {})
+        self.egtdatavalues = [0] * len(self.EGT.get("dbkeys", []))
+        self.chtvalues = [0] * len(self.CHT.get("dbkeys", []))
+        self.egtdatamax = [0] * len(self.EGT.get("dbkeys", []))
+        self.chtmax = [0] * len(self.CHT.get("dbkeys", []))
+        self.update_timer = QTimer(self)
+        self.update_timer.timeout.connect(self.update_data)
+        self.update_timer.start(1000)
+
+    def update_data(self):
+        for i, dbkey in enumerate(self.EGT.get("dbkeys", [])):
+            item = fix.db.get_item(dbkey)
+            self.egtdatavalues[i] = item.value
+            if item.value > self.egtdatamax[i]:
+                self.egtdatamax[i] = item.value
+        for i, dbkey in enumerate(self.CHT.get("dbkeys", [])):
+            item = fix.db.get_item(dbkey)
+            self.chtvalues[i] = item.value
+            if item.value > self.chtmax[i]:
+                self.chtmax[i] = item.value
+        self.update()
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        self.draw_background(painter)
+        self.draw_labels(painter)
+        self.draw_data(painter)
+
+    def draw_background(self, painter):
+        painter.fillRect(self.rect(), QColor(Qt.GlobalColor.black))
+        pen = QPen(QColor(Qt.GlobalColor.gray))
+        pen.setWidth(1)
+        painter.setPen(pen)
+        painter.drawLine(self.width() // 2, 0, self.width() // 2, self.height())
+
+    def draw_labels(self, painter):
+        font = QFont()
+        font.setPixelSize(int(self.height() * self.headpct))
+        painter.setFont(font)
+        painter.setPen(QColor(Qt.GlobalColor.white))
+        painter.drawText(QRectF(0, 0, self.width() // 2, self.height() * self.headpct), Qt.AlignmentFlag.AlignCenter, "EGT")
+        painter.drawText(QRectF(self.width() // 2, 0, self.width() // 2, self.height() * self.headpct), Qt.AlignmentFlag.AlignCenter, "CHT")
+
+    def draw_data(self, painter):
+        element_height = (self.height() * (1 - self.headpct) - (len(self.egtdatavalues) - 1) * self.height() * self.gappct) / len(self.egtdatavalues)
+        for i, value in enumerate(self.egtdatavalues):
+            self.draw_element(painter, value, self.egtdatamax[i], self.EGT, i, True, element_height)
+        for i, value in enumerate(self.chtvalues):
+            self.draw_element(painter, value, self.chtmax[i], self.CHT, i, False, element_height)
+
+    def draw_element(self, painter, value, maxvalue, config, index, is_egt, element_height):
+        minlimit = config.get("minlimit", 0)
+        warnlimit = config.get("warnlimit", 0)
+        maxlimit = config.get("maxlimit", 0)
+        maxextendpct = config.get("maxextendpct", 0)
+        bar_range = maxlimit + (maxextendpct * (maxlimit - minlimit)) - minlimit
+        bar_length = (value - minlimit) / bar_range * (self.width() // 2)
+        maxbar_length = (maxvalue - minlimit) / bar_range * (self.width() // 2)
+        y = self.height() * self.headpct + index * (element_height + self.height() * self.gappct)
+        if is_egt:
+            x = self.width() // 2 - bar_length
+            maxx = self.width() // 2 - maxbar_length
+            textx = self.width() // 2 - bar_length - 20
+        else:
+            x = self.width() // 2
+            maxx = self.width() // 2 + maxbar_length
+            textx = self.width() // 2 + bar_length + 20
+
+        if value < minlimit:
+            color = QColor(Qt.GlobalColor.white)
+            if any(v > minlimit for v in (self.egtdatavalues if is_egt else self.chtvalues)):
+                color = QColor(Qt.GlobalColor.red)
+            painter.setPen(color)
+            painter.drawText(QRectF(textx, y, 40, element_height), Qt.AlignmentFlag.AlignCenter, str(int(value)))
+        else:
+            if value >= maxlimit:
+                color = QColor(Qt.GlobalColor.red)
+                painter.setPen(QColor(Qt.GlobalColor.white))
+                painter.drawText(QRectF(textx, y, 40, element_height), Qt.AlignmentFlag.AlignCenter, str(int(value)))
+            elif value >= warnlimit:
+                color = QColor(Qt.GlobalColor.orange)
+            else:
+                color = QColor(Qt.GlobalColor.green)
+            painter.setBrush(color)
+            painter.drawRect(QRectF(x, y, bar_length, element_height))
+
+        painter.setPen(QColor(Qt.GlobalColor.red))
+        painter.drawLine(maxx, y, maxx, y + element_height)
+        painter.setPen(color)
+        painter.drawLine(self.width() // 2, y, self.width() // 2, y + element_height)

--- a/src/pyefis/instruments/gauges/__init__.py
+++ b/src/pyefis/instruments/gauges/__init__.py
@@ -20,3 +20,4 @@ from .verticalBar import VerticalBar
 from .arc import ArcGauge
 from .numeric import NumericDisplay
 from .egt import EGTGroup
+from .EGTCHT_Combo import EGTCHT_Combo

--- a/src/pyefis/screens/screenbuilder.py
+++ b/src/pyefis/screens/screenbuilder.py
@@ -503,6 +503,8 @@ class Screen(QWidget):
             self.instruments[count] = gauges.VerticalBar(self,min_size=False,font_family=font_family)
         elif i['type'] == 'virtual_vfr':
             self.instruments[count] = VirtualVfr(self,font_percent=font_percent,font_family=font_family)
+        elif i['type'] == 'EGTCHT_Combo':
+            self.instruments[count] = gauges.EGTCHT_Combo(self, config=i['options'])
 
         elif i['type'] == 'listbox':
             self.instruments[count] = listbox.ListBox(self, lists=i['options']['lists'], replace=replace,font_family=font_family) #,font_percent=font_percent)

--- a/tests/instruments/gauges/test_EGTCHT_Combo.py
+++ b/tests/instruments/gauges/test_EGTCHT_Combo.py
@@ -1,0 +1,110 @@
+import pytest
+from PyQt6.QtWidgets import QApplication
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor, QFont, QPainter, QPen, QTimer, QRectF
+from pyefis.instruments.gauges.EGTCHT_Combo import EGTCHT_Combo
+import pyavtools.fix as fix
+
+@pytest.fixture
+def app(qtbot):
+    test_app = QApplication.instance()
+    if test_app is None:
+        test_app = QApplication([])
+    return test_app
+
+def test_EGTCHT_Combo_config(app, qtbot):
+    config = {
+        "rows": 4,
+        "cols": 2,
+        "gappct": 0.05,
+        "headpct": 0.1,
+        "EGT": {
+            "minlimit": 1000,
+            "warnlimit": 1300,
+            "maxlimit": 1600,
+            "maxextendpct": 0.1,
+            "dbkeys": ["EGT1", "EGT2", "EGT3", "EGT4"]
+        },
+        "CHT": {
+            "minlimit": 300,
+            "warnlimit": 400,
+            "maxlimit": 500,
+            "maxextendpct": 0.1,
+            "dbkeys": ["CHT1", "CHT2", "CHT3", "CHT4"]
+        }
+    }
+    widget = EGTCHT_Combo(config=config)
+    assert widget.rows == 4
+    assert widget.cols == 2
+    assert widget.gappct == 0.05
+    assert widget.headpct == 0.1
+    assert widget.EGT["minlimit"] == 1000
+    assert widget.EGT["warnlimit"] == 1300
+    assert widget.EGT["maxlimit"] == 1600
+    assert widget.EGT["maxextendpct"] == 0.1
+    assert widget.EGT["dbkeys"] == ["EGT1", "EGT2", "EGT3", "EGT4"]
+    assert widget.CHT["minlimit"] == 300
+    assert widget.CHT["warnlimit"] == 400
+    assert widget.CHT["maxlimit"] == 500
+    assert widget.CHT["maxextendpct"] == 0.1
+    assert widget.CHT["dbkeys"] == ["CHT1", "CHT2", "CHT3", "CHT4"]
+
+def test_EGTCHT_Combo_data_structures(app, qtbot):
+    config = {
+        "rows": 4,
+        "cols": 2,
+        "gappct": 0.05,
+        "headpct": 0.1,
+        "EGT": {
+            "minlimit": 1000,
+            "warnlimit": 1300,
+            "maxlimit": 1600,
+            "maxextendpct": 0.1,
+            "dbkeys": ["EGT1", "EGT2", "EGT3", "EGT4"]
+        },
+        "CHT": {
+            "minlimit": 300,
+            "warnlimit": 400,
+            "maxlimit": 500,
+            "maxextendpct": 0.1,
+            "dbkeys": ["CHT1", "CHT2", "CHT3", "CHT4"]
+        }
+    }
+    widget = EGTCHT_Combo(config=config)
+    assert widget.egtdatavalues == [0, 0, 0, 0]
+    assert widget.chtvalues == [0, 0, 0, 0]
+    assert widget.egtdatamax == [0, 0, 0, 0]
+    assert widget.chtmax == [0, 0, 0, 0]
+
+def test_EGTCHT_Combo_visual_presentation(app, qtbot):
+    config = {
+        "rows": 4,
+        "cols": 2,
+        "gappct": 0.05,
+        "headpct": 0.1,
+        "EGT": {
+            "minlimit": 1000,
+            "warnlimit": 1300,
+            "maxlimit": 1600,
+            "maxextendpct": 0.1,
+            "dbkeys": ["EGT1", "EGT2", "EGT3", "EGT4"]
+        },
+        "CHT": {
+            "minlimit": 300,
+            "warnlimit": 400,
+            "maxlimit": 500,
+            "maxextendpct": 0.1,
+            "dbkeys": ["CHT1", "CHT2", "CHT3", "CHT4"]
+        }
+    }
+    widget = EGTCHT_Combo(config=config)
+    qtbot.addWidget(widget)
+    widget.resize(400, 300)
+    widget.show()
+    qtbot.waitExposed(widget)
+    painter = QPainter(widget)
+    widget.paintEvent(None)
+    assert painter.isActive()
+    assert widget.isVisible()
+    assert widget.width() == 400
+    assert widget.height() == 300


### PR DESCRIPTION
Add a new PyQt widget module "EGTCHT_Combo" to display EGT and CHT data.

* Create `EGTCHT_Combo` class in `src/pyefis/instruments/gauges/EGTCHT_Combo.py` with configuration items: `rows`, `cols`, `gappct`, `headpct`, `EGT`, `CHT`.
* Implement logic to read from the FIX database using defined `dbkeys` at a one-second update rate.
* Implement visual presentation of the widget with EGT data on the left and CHT data on the right.
* Import `EGTCHT_Combo` class in `src/pyefis/instruments/gauges/__init__.py` and add it to the list of available gauges.
* Add a new configuration file `src/pyefis/config/includes/bars/vertical/EGTCHT_Combo.yaml` defining the configuration items and data structures for `EGT` and `CHT`.
* Update `src/pyefis/screens/screenbuilder.py` to handle the new `EGTCHT_Combo` widget type and support it in the `load_instrument` method.
* Create a new test file `tests/instruments/gauges/test_EGTCHT_Combo.py` with unit tests to verify the configuration items, data structures, and visual presentation of the widget.

