### PR TITLE
Add Historic_LinePlot widget

### DIFF
--- a/src/pyefis/instruments/gauges/Historic_LinePlot.py
+++ b/src/pyefis/instruments/gauges/Historic_LinePlot.py
@@ -1,0 +1,79 @@
+from PyQt6.QtWidgets import QWidget
+from PyQt6.QtGui import QPainter, QColor, QPen, QFont
+from PyQt6.QtCore import QTimer, QRectF, Qt
+import pyavtools.fix as fix
+
+class Historic_LinePlot(QWidget):
+    def __init__(self, parent=None):
+        super(Historic_LinePlot, self).__init__(parent)
+        self.rows = 0
+        self.cols = 0
+        self.maxpens = 0
+        self.maxnumvals = 0
+        self.pens = []
+        self.data = {}
+        self.timer = QTimer(self)
+        self.timer.timeout.connect(self.update_data)
+        self.timer.start(1000)
+
+    def configure(self, config):
+        self.rows = config.get("rows", 0)
+        self.cols = config.get("cols", 0)
+        self.maxpens = config.get("maxpens", 0)
+        self.maxnumvals = config.get("maxnumvals", 0)
+        for i in range(self.maxpens):
+            pen_config = config.get(f"pen{i}", {})
+            pen = {
+                "name": pen_config.get("name", ""),
+                "height": pen_config.get("height", 0),
+                "dbkey": pen_config.get("dbkey", ""),
+                "color": pen_config.get("color", "#FFFFFF"),
+                "thk": pen_config.get("thk", 1),
+                "miny": pen_config.get("miny", 0),
+                "maxy": pen_config.get("maxy", 100),
+                "limity": pen_config.get("limity", None),
+            }
+            self.pens.append(pen)
+            self.data[pen["dbkey"]] = []
+
+    def update_data(self):
+        for pen in self.pens:
+            item = fix.db.get_item(pen["dbkey"])
+            value = item.value
+            if len(self.data[pen["dbkey"]]) >= self.maxnumvals:
+                self.data[pen["dbkey"]].pop(0)
+            self.data[pen["dbkey"]].append(value)
+        self.update()
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.fillRect(self.rect(), Qt.GlobalColor.black)
+
+        # Draw pen names
+        pen_width = self.width() / self.maxpens
+        for i, pen in enumerate(self.pens):
+            painter.setPen(QColor(pen["color"]))
+            font = QFont()
+            font.setPixelSize(pen["height"])
+            painter.setFont(font)
+            text_rect = QRectF(i * pen_width, 0, pen_width, pen["height"])
+            painter.drawText(text_rect, Qt.AlignmentFlag.AlignCenter, pen["name"])
+
+        # Draw line plots
+        plot_height = self.height() - pen["height"]
+        for pen in self.pens:
+            painter.setPen(QPen(QColor(pen["color"]), pen["thk"]))
+            for j in range(1, len(self.data[pen["dbkey"]])):
+                x1 = (j - 1) * (self.width() / self.maxnumvals)
+                y1 = plot_height - ((self.data[pen["dbkey"]][j - 1] - pen["miny"]) / (pen["maxy"] - pen["miny"]) * plot_height)
+                x2 = j * (self.width() / self.maxnumvals)
+                y2 = plot_height - ((self.data[pen["dbkey"]][j] - pen["miny"]) / (pen["maxy"] - pen["miny"]) * plot_height)
+                painter.drawLine(x1, y1, x2, y2)
+
+            if pen["limity"] is not None:
+                painter.setPen(QPen(Qt.GlobalColor.white, pen["thk"], Qt.PenStyle.DashLine))
+                y = plot_height - ((pen["limity"] - pen["miny"]) / (pen["maxy"] - pen["miny"]) * plot_height)
+                painter.drawLine(0, y, self.width(), y)
+
+        painter.end()

--- a/src/pyefis/instruments/gauges/__init__.py
+++ b/src/pyefis/instruments/gauges/__init__.py
@@ -20,3 +20,4 @@ from .verticalBar import VerticalBar
 from .arc import ArcGauge
 from .numeric import NumericDisplay
 from .egt import EGTGroup
+from .Historic_LinePlot import Historic_LinePlot

--- a/src/pyefis/screens/screenbuilder.py
+++ b/src/pyefis/screens/screenbuilder.py
@@ -503,6 +503,9 @@ class Screen(QWidget):
             self.instruments[count] = gauges.VerticalBar(self,min_size=False,font_family=font_family)
         elif i['type'] == 'virtual_vfr':
             self.instruments[count] = VirtualVfr(self,font_percent=font_percent,font_family=font_family)
+        elif i['type'] == 'historic_line_plot':
+            self.instruments[count] = gauges.Historic_LinePlot(self)
+            self.instruments[count].configure(i['options'])
 
         elif i['type'] == 'listbox':
             self.instruments[count] = listbox.ListBox(self, lists=i['options']['lists'], replace=replace,font_family=font_family) #,font_percent=font_percent)

--- a/tests/instruments/gauges/test_historic_line_plot.py
+++ b/tests/instruments/gauges/test_historic_line_plot.py
@@ -1,0 +1,137 @@
+import pytest
+from PyQt6.QtWidgets import QApplication
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor, QPainter, QPen, QFont
+from pyefis.instruments.gauges.Historic_LinePlot import Historic_LinePlot
+import pyavtools.fix as fix
+
+@pytest.fixture
+def app(qtbot):
+    test_app = QApplication.instance()
+    if test_app is None:
+        test_app = QApplication([])
+    return test_app
+
+def test_historic_line_plot_initialization(app, qtbot):
+    widget = Historic_LinePlot()
+    qtbot.addWidget(widget)
+    assert widget.rows == 0
+    assert widget.cols == 0
+    assert widget.maxpens == 0
+    assert widget.maxnumvals == 0
+    assert widget.pens == []
+    assert widget.data == {}
+
+def test_historic_line_plot_configuration(app, qtbot):
+    widget = Historic_LinePlot()
+    qtbot.addWidget(widget)
+    config = {
+        "rows": 2,
+        "cols": 3,
+        "maxpens": 2,
+        "maxnumvals": 10,
+        "pen0": {
+            "name": "Pen 1",
+            "height": 12,
+            "dbkey": "dbkey1",
+            "color": "#FF0000",
+            "thk": 2,
+            "miny": 0,
+            "maxy": 100,
+            "limity": 50,
+        },
+        "pen1": {
+            "name": "Pen 2",
+            "height": 14,
+            "dbkey": "dbkey2",
+            "color": "#00FF00",
+            "thk": 3,
+            "miny": 10,
+            "maxy": 90,
+            "limity": 60,
+        },
+    }
+    widget.configure(config)
+    assert widget.rows == 2
+    assert widget.cols == 3
+    assert widget.maxpens == 2
+    assert widget.maxnumvals == 10
+    assert len(widget.pens) == 2
+    assert widget.pens[0]["name"] == "Pen 1"
+    assert widget.pens[1]["name"] == "Pen 2"
+    assert widget.data["dbkey1"] == []
+    assert widget.data["dbkey2"] == []
+
+def test_historic_line_plot_update_data(app, qtbot):
+    widget = Historic_LinePlot()
+    qtbot.addWidget(widget)
+    config = {
+        "rows": 2,
+        "cols": 3,
+        "maxpens": 2,
+        "maxnumvals": 10,
+        "pen0": {
+            "name": "Pen 1",
+            "height": 12,
+            "dbkey": "dbkey1",
+            "color": "#FF0000",
+            "thk": 2,
+            "miny": 0,
+            "maxy": 100,
+            "limity": 50,
+        },
+        "pen1": {
+            "name": "Pen 2",
+            "height": 14,
+            "dbkey": "dbkey2",
+            "color": "#00FF00",
+            "thk": 3,
+            "miny": 10,
+            "maxy": 90,
+            "limity": 60,
+        },
+    }
+    widget.configure(config)
+    fix.db.get_item = lambda dbkey: type("MockItem", (object,), {"value": 42})()
+    widget.update_data()
+    assert widget.data["dbkey1"] == [42]
+    assert widget.data["dbkey2"] == [42]
+
+def test_historic_line_plot_paint_event(app, qtbot):
+    widget = Historic_LinePlot()
+    qtbot.addWidget(widget)
+    config = {
+        "rows": 2,
+        "cols": 3,
+        "maxpens": 2,
+        "maxnumvals": 10,
+        "pen0": {
+            "name": "Pen 1",
+            "height": 12,
+            "dbkey": "dbkey1",
+            "color": "#FF0000",
+            "thk": 2,
+            "miny": 0,
+            "maxy": 100,
+            "limity": 50,
+        },
+        "pen1": {
+            "name": "Pen 2",
+            "height": 14,
+            "dbkey": "dbkey2",
+            "color": "#00FF00",
+            "thk": 3,
+            "miny": 10,
+            "maxy": 90,
+            "limity": 60,
+        },
+    }
+    widget.configure(config)
+    fix.db.get_item = lambda dbkey: type("MockItem", (object,), {"value": 42})()
+    widget.update_data()
+    widget.resize(400, 300)
+    widget.show()
+    qtbot.waitExposed(widget)
+    painter = QPainter(widget)
+    widget.paintEvent(None)
+    assert painter.isActive()


### PR DESCRIPTION
Add a new PyQt widget module `Historic_LinePlot` to display scrolling line plots.

* **Historic_LinePlot.py**
  - Define `Historic_LinePlot` class inheriting from `QWidget`.
  - Implement `__init__` method to initialize the widget and set up the configuration.
  - Implement `configure` method to set up the configuration items for the widget.
  - Implement `update_data` method to read data from the FIX database and update the line plots.
  - Implement `paintEvent` method to draw the line plots and pen names on the widget.

* **__init__.py**
  - Import `Historic_LinePlot` class.
  - Add `Historic_LinePlot` to the list of available gauges.

* **screenbuilder.py**
  - Add a case for `historic_line_plot` in the `setup_instruments` method to create an instance of `Historic_LinePlot`.
  - Update the `load_instrument` method to handle the configuration of `Historic_LinePlot`.

* **test_historic_line_plot.py**
  - Import `Historic_LinePlot` class and necessary testing libraries.
  - Write unit tests for `Historic_LinePlot` class, including tests for initialization, data update, and drawing.

